### PR TITLE
Revert "Update dependency AdGuard to v0.107.66"

### DIFF
--- a/roles/dns-server/defaults/main.yml
+++ b/roles/dns-server/defaults/main.yml
@@ -9,7 +9,7 @@ dns_server_adguard_arch_to_package_suffix:
   x86_64: amd64
 
 # renovate: github-releases=AdguardTeam/AdGuardHome depName=AdGuard
-dns_server_adguard_release_version: v0.107.66
+dns_server_adguard_release_version: v0.107.65
 
 # renovate: github-releases=DNSCrypt/dnscrypt-proxy depName=DNSCrypt-Proxy
 dns_server_dnscrypt_release_version: 2.1.14


### PR DESCRIPTION
This reverts commit a69329a2ab3eccafdd37e56d0afacc7501b0f8de.